### PR TITLE
Fix fast matched filter import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     packages=["BPMF"],
     install_requires=[
         "beampower",
-        "fast_matched_filter",
+        "FastMatchedFilter",
         "h5py",
         "matplotlib",
         "numpy",


### PR DESCRIPTION
Installing Seismic_BPMF threw error:

```
ERROR: Could not find a version that satisfies the requirement fast_matched_filter (from bpmf) (from versions: none)

ERROR: No matching distribution found for fast_matched_filter
```


Fast matched filter installs under name `FastMatchedFilter`. Fixed in `setup.py` and installation works.